### PR TITLE
feature/one active tierlist

### DIFF
--- a/backend/routes/tierlist.go
+++ b/backend/routes/tierlist.go
@@ -53,7 +53,12 @@ func createNewTierlist(c *gin.Context, svc *services.TierlistService) {
 	creatorID := c.MustGet("user").(models.User).ID
 	result, err := svc.Create(req, creatorID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Database Error"})
+		switch {
+		case errors.Is(err, services.ErrUniqueViolation):
+			c.JSON(http.StatusConflict, gin.H{"error": "Only one active tierlist allowed at a time."})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Database Error"})
+		}
 		return
 	}
 	c.JSON(http.StatusCreated, result)

--- a/backend/routes/tierlist.go
+++ b/backend/routes/tierlist.go
@@ -55,7 +55,7 @@ func createNewTierlist(c *gin.Context, svc *services.TierlistService) {
 	if err != nil {
 		switch {
 		case errors.Is(err, services.ErrUniqueViolation):
-			c.JSON(http.StatusConflict, gin.H{"error": "Only one active tierlist allowed at a time."})
+			c.JSON(http.StatusConflict, gin.H{"error": "You already have an active tierlist. Wait for it to expire or delete it before creating a new one."})
 		default:
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Database Error"})
 		}

--- a/backend/services/tierlist_service.go
+++ b/backend/services/tierlist_service.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	ErrNotFound  = errors.New("not found")
-	ErrForbidden = errors.New("forbidden")
-	ErrConflict  = errors.New("already submitted")
-	ErrExpired   = errors.New("voting closed")
+	ErrNotFound        = errors.New("not found")
+	ErrForbidden       = errors.New("forbidden")
+	ErrConflict        = errors.New("already submitted")
+	ErrExpired         = errors.New("voting closed")
+	ErrUniqueViolation = errors.New("only one tierlist allowed at a time")
 )
 
 type TierlistService struct {
@@ -64,6 +65,11 @@ func (s *TierlistService) GetByID(id string, userID *uuid.UUID) (*dto.TierlistRe
 
 func (s *TierlistService) Create(req dto.CreateTierlistRequest, creatorID uuid.UUID) (*dto.CreateTierlistResponse, error) {
 	var result dto.CreateTierlistResponse
+
+	if err := s.db.Where("creator_id = ? AND expiry_time > ?", creatorID, time.Now()).First(&models.Tierlist{}).Error; err == nil {
+		return nil, ErrUniqueViolation
+	}
+
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		tierlist := models.Tierlist{
 			Title:       req.Title,

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,7 +1,7 @@
 <div class="min-h-screen bg-base-200 text-base-content">
   <header class="navbar bg-base-100 shadow-sm px-4">
     <div class="flex-1">
-      <a routerLink="/" class="btn btn-ghost text-xl font-bold">Tier List Creator</a>
+      <a routerLink="/" class="btn btn-ghost text-xl font-bold">Tierlist Creator</a>
     </div>
     <div class="flex-none items-center gap-2">
       <button

--- a/frontend/src/app/pages/create/create.html
+++ b/frontend/src/app/pages/create/create.html
@@ -1,9 +1,9 @@
 <div class="max-w-2xl mx-auto">
-  <h1 class="text-2xl font-bold mb-4">Create a tier list</h1>
+  <h1 class="text-2xl font-bold mb-4">Create a tierlist</h1>
 
   @if (!user()) {
     <div class="alert alert-warning mb-4">
-      <span>You need to be logged in to create a tier list.</span>
+      <span>You need to be logged in to create a tierlist.</span>
     </div>
   }
 
@@ -30,7 +30,7 @@
       <textarea
         class="textarea textarea-bordered w-full"
         rows="2"
-        placeholder="What's this tier list about?"
+        placeholder="What's this tierlist about?"
         [value]="description()"
         (input)="description.set($any($event.target).value)"
       ></textarea>
@@ -107,7 +107,7 @@
       @if (submitting()) {
         <span class="loading loading-spinner loading-sm"></span>
       }
-      Create tier list
+      Create tierlist
     </button>
   </form>
 </div>

--- a/frontend/src/app/pages/create/create.ts
+++ b/frontend/src/app/pages/create/create.ts
@@ -87,8 +87,8 @@ export class Create {
           this.submitting.set(false);
           this.error.set(
             err?.status === 401
-              ? 'You need to log in to create a tier list.'
-              : err?.error?.error || 'Something went wrong creating the tier list.',
+              ? 'You need to log in to create a tierlist.'
+              : err?.error?.error || 'Something went wrong creating the tierlist.',
           );
         },
       });

--- a/frontend/src/app/pages/home/home.html
+++ b/frontend/src/app/pages/home/home.html
@@ -1,6 +1,6 @@
 <div class="flex flex-col gap-8 items-center text-center py-10">
   <div class="max-w-2xl">
-    <h1 class="text-4xl font-bold mb-3">Create &amp; vote on tier lists</h1>
+    <h1 class="text-4xl font-bold mb-3">Create &amp; vote on tierlists</h1>
     <p class="text-base-content/70">
       Build a list of items, share the link, and let everyone rank them from S to F.
       Then see the aggregated results.
@@ -9,17 +9,17 @@
 
   @if (user()) {
     <div class="flex flex-col sm:flex-row gap-3">
-      <a routerLink="/create" class="btn btn-primary btn-lg">Create a tier list</a>
+      <a routerLink="/create" class="btn btn-primary btn-lg">Create a tierlist</a>
     </div>
 
     <div class="card bg-base-100 shadow-sm w-full max-w-md">
       <div class="card-body">
-        <h2 class="card-title text-base">Open an existing tier list</h2>
+        <h2 class="card-title text-base">Open an existing tierlist</h2>
         <div class="join w-full">
           <input
             class="input input-bordered join-item w-full"
             type="text"
-            placeholder="Paste a tier list ID or link…"
+            placeholder="Paste a tierlist ID or link…"
             (input)="onOpenInput($any($event.target).value)"
             (keydown.enter)="open()"
           />

--- a/frontend/src/app/pages/results/results.ts
+++ b/frontend/src/app/pages/results/results.ts
@@ -69,7 +69,7 @@ export class Results {
       error: (err) => {
         this.loading.set(false);
         this.error.set(
-          err?.status === 404 ? 'Tier list not found.' : 'Failed to load results.',
+          err?.status === 404 ? 'Tierlist not found.' : 'Failed to load results.',
         );
       },
     });

--- a/frontend/src/app/pages/vote/vote.ts
+++ b/frontend/src/app/pages/vote/vote.ts
@@ -58,7 +58,7 @@ export class Vote {
 
   constructor() {
     if (!this.id) {
-      this.error.set('No tier list specified.');
+      this.error.set('No tierlist specified.');
       this.loading.set(false);
       return;
     }
@@ -76,7 +76,7 @@ export class Vote {
       error: (err) => {
         this.loading.set(false);
         this.error.set(
-          err?.status === 404 ? 'Tier list not found.' : 'Failed to load tier list.',
+          err?.status === 404 ? 'Tierlist not found.' : 'Failed to load tierlist.',
         );
       },
     });

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,15 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Tier List Creator</title>
+  <title>Tierlist Creator</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Create tier lists, share the link, and let everyone rank items from S to F — then see the aggregated community results.">
+  <meta name="description" content="Create tierlists, share the link, and let everyone rank items from S to F — then see the aggregated community results.">
 
   <!-- Open Graph / social share previews -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Tier List Creator">
-  <meta property="og:description" content="Build a tier list, share the link, and vote from S to F.">
+  <meta property="og:title" content="Tierlist Creator">
+  <meta property="og:description" content="Build a tierlist, share the link, and vote from S to F.">
 
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
Constrains the user to only have one active tierlist. Once deleted / expired, user is then free to create another.
- Checked on the backend, sentinel error created and sent to the frontend if constraint is hit.

Fixes:
- "tier list" to "tierlist" for unity across the frontend.
- Improved the actual error message received on the frontend when creating a tierlist with one already active.